### PR TITLE
Add workflow to update cluster-monitoring-operator/versions.yaml

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -1,0 +1,21 @@
+name: Update Version
+
+on: [delete]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Get token to trigger update version workflow
+        id: update-version
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.UPDATE_VERSION_APP_ID }}
+          private_key: ${{ secrets.UPDATE_VERSION_APP_PRIVATE_KEY }}
+          scope: ${{ github.repository_owner }}
+      - name: Trigger update version workflow
+        run: |
+         curl -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ steps.update-version.outputs.token }}" \
+            --request POST \
+            https://api.github.com/repos/${{ github.repository_owner }}/syncbot/actions/workflows/update-cmo-deps-versions.yaml/dispatches -d '{"ref":"main"}'


### PR DESCRIPTION
This commit adds a github action listener for branch delete event which
happens when upstream -> downstream PR is merged with openshift repos.
Once the event occurs, newly added action invokes rhobs/syncbot workflow
which creates PR to bump the version.yaml.

New Github app [version-bumper](https://github.com/apps/version-bumper) has been created to ease the process which provides token to trigger workflow.


Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
